### PR TITLE
fix(nextjs): use sm: breakpoint for mobile RWD

### DIFF
--- a/apps/nextjs-playground/src/app/(chakra-ui-template)/home.tsx
+++ b/apps/nextjs-playground/src/app/(chakra-ui-template)/home.tsx
@@ -10,8 +10,8 @@ const linkCls = 'text-blue-600 hover:underline dark:text-blue-400';
 
 const Index = () => (
   <Container className="h-full">
-    <Main className="block h-full p-12 md:flex md:p-4">
-      <div className="mb-8 h-auto w-full overflow-auto md:h-full md:w-1/2">
+    <Main className="block h-full px-4 py-12 sm:flex sm:p-4">
+      <div className="mb-8 h-auto w-full overflow-auto sm:h-full sm:w-1/2">
         <h3 className="text-lg font-semibold">React Three Fiber playground</h3>
         <ul className="list-disc space-y-1 pt-4 pl-5">
           <li>
@@ -66,7 +66,7 @@ const Index = () => (
           </li>
         </ul>
       </div>
-      <div className="h-auto w-full overflow-auto md:h-full md:w-1/2">
+      <div className="h-auto w-full overflow-auto sm:h-full sm:w-1/2">
         <h3 className="text-lg font-semibold">Three.js playground</h3>
         <ul className="list-disc space-y-1 pt-4 pl-5">
           <li>

--- a/apps/nextjs-playground/src/components/layout/NavOrAside.tsx
+++ b/apps/nextjs-playground/src/components/layout/NavOrAside.tsx
@@ -3,11 +3,11 @@ import { FiGithub, FiLinkedin, FiTwitter } from 'react-icons/fi';
 
 export const NavOrAside = () => {
   return (
-    <div className="flex items-baseline justify-between md:block md:justify-normal">
+    <div className="flex items-baseline justify-between sm:block sm:justify-normal">
       <Link href="/">
         <h1 className="shrink-0 cursor-pointer text-2xl font-bold">Hank Lin</h1>
       </Link>
-      <div className="flex flex-row md:flex-col">
+      <div className="flex flex-row sm:flex-col">
         <a
           href="https://github.com/jyunhanlin"
           target="_blank"
@@ -16,7 +16,7 @@ export const NavOrAside = () => {
         >
           <span className="flex items-center">
             <FiGithub />
-            <span className="hidden pl-2 md:inline">GitHub</span>
+            <span className="hidden pl-2 sm:inline">GitHub</span>
           </span>
         </a>
         <a
@@ -27,7 +27,7 @@ export const NavOrAside = () => {
         >
           <span className="flex items-center">
             <FiTwitter />
-            <span className="hidden pl-2 md:inline">Twitter</span>
+            <span className="hidden pl-2 sm:inline">Twitter</span>
           </span>
         </a>
         <a
@@ -38,7 +38,7 @@ export const NavOrAside = () => {
         >
           <span className="flex items-center">
             <FiLinkedin />
-            <span className="hidden pl-2 md:inline">Linkedin</span>
+            <span className="hidden pl-2 sm:inline">Linkedin</span>
           </span>
         </a>
       </div>


### PR DESCRIPTION
## Summary
- Switch responsive classes from `md:` (768px) back to `sm:` (640px) — Chakra's `[base, sm]` array syntax mapped to its 40em/640px breakpoint, so layouts weren't collapsing at phone widths.
- Fix home padding from `p-12` (all sides) to `px-4 py-12` to match the original `3rem 1rem` mobile padding.

## Test plan
- [x] `pnpm run next:build` succeeds
- [ ] Verify home page layout collapses to single column on phone widths after deployment
- [ ] Verify nav icons show labels on desktop (sm+) only