### PR TITLE
feat(nextjs): connect macbook to monitor with cable and embed youtube on screen

### DIFF
--- a/apps/nextjs-playground/src/components/r3f/StandingDesk.tsx
+++ b/apps/nextjs-playground/src/components/r3f/StandingDesk.tsx
@@ -2,8 +2,8 @@
 
 import { ContactShadows, Environment, OrbitControls, RoundedBox } from '@react-three/drei';
 import { Canvas, useFrame } from '@react-three/fiber';
-import { Suspense, useRef, useState } from 'react';
-import { Group, Mesh, MathUtils } from 'three';
+import { Suspense, useMemo, useRef, useState } from 'react';
+import { CatmullRomCurve3, Group, MathUtils, Mesh, TubeGeometry, Vector3 } from 'three';
 
 const MIN_HEIGHT = 0.65;
 const MAX_HEIGHT = 1.25;
@@ -77,6 +77,7 @@ function DeskRig({ heightRef, dirRef, onDisplayUpdate }: DeskRigProps) {
         <MacBookAir position={[-0.5, 0, 0]} />
         <NuPhyKeyboard position={[0, 0, 0.18]} />
         <MxMasterMouse position={[0.27, 0, 0.2]} />
+        <DisplayCable />
       </group>
 
       <Leg x={-0.65} innerRef={innerLegLeftRef} />
@@ -197,6 +198,26 @@ function MxMasterMouse({ position }: DeskItemProps) {
         <meshStandardMaterial color="#3a3a3c" roughness={0.4} metalness={0.3} />
       </mesh>
     </group>
+  );
+}
+
+function DisplayCable() {
+  const geometry = useMemo(() => {
+    const curve = new CatmullRomCurve3([
+      new Vector3(-0.65, 0.005, 0.0),
+      new Vector3(-0.62, 0.004, -0.08),
+      new Vector3(-0.45, 0.004, -0.16),
+      new Vector3(-0.22, 0.004, -0.215),
+      new Vector3(-0.05, 0.005, -0.225),
+      new Vector3(0, 0.1, -0.225),
+    ]);
+    return new TubeGeometry(curve, 80, 0.0035, 8, false);
+  }, []);
+
+  return (
+    <mesh geometry={geometry} castShadow>
+      <meshStandardMaterial color="#1a1a1c" roughness={0.7} metalness={0.1} />
+    </mesh>
   );
 }
 

--- a/apps/nextjs-playground/src/components/r3f/StandingDesk.tsx
+++ b/apps/nextjs-playground/src/components/r3f/StandingDesk.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ContactShadows, Environment, OrbitControls, RoundedBox } from '@react-three/drei';
+import { ContactShadows, Environment, Html, OrbitControls, RoundedBox } from '@react-three/drei';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { Suspense, useMemo, useRef, useState } from 'react';
 import { CatmullRomCurve3, Group, MathUtils, Mesh, TubeGeometry, Vector3 } from 'three';
@@ -15,6 +15,8 @@ const DESKTOP_THICKNESS = 0.04;
 const DESKTOP_HALF = DESKTOP_THICKNESS / 2;
 const OUTER_LEG_HEIGHT = 0.55;
 const INNER_LEG_HEIGHT = 1.25;
+
+const YOUTUBE_VIDEO_ID = 'dQw4w9WgXcQ';
 
 type Direction = -1 | 0 | 1;
 
@@ -73,6 +75,17 @@ function DeskRig({ heightRef, dirRef, onDisplayUpdate }: DeskRigProps) {
           <boxGeometry args={[0.5, 0.32, 0.03]} />
           <meshStandardMaterial color="#1f1f22" roughness={0.4} metalness={0.2} />
         </mesh>
+        <Html transform position={[0, 0.27, -0.184]} scale={0.0014} distanceFactor={1} zIndexRange={[1, 0]}>
+          <iframe
+            width="320"
+            height="180"
+            src={`https://www.youtube.com/embed/${YOUTUBE_VIDEO_ID}`}
+            title="YouTube video"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowFullScreen
+            style={{ border: 0, display: 'block', background: '#000' }}
+          />
+        </Html>
 
         <MacBookAir position={[-0.5, 0, 0]} />
         <NuPhyKeyboard position={[0, 0, 0.18]} />


### PR DESCRIPTION
## Summary
- **USB-C cable**: tube geometry along a Catmull-Rom curve drapes from the MacBook's left port across the desk and up to the back of the monitor
- **YouTube embed**: drei `<Html transform>` places an iframe in 3D space, aligned to the monitor's front face. `YOUTUBE_VIDEO_ID` constant near the top of the file makes it trivial to swap

https://claude.ai/code/session_01PgzjxBWpdaDx776H7gYJdz