### PR TITLE
feat(nextjs): autoplay and loop the embedded youtube video on the monitor

### DIFF
--- a/apps/nextjs-playground/src/components/r3f/StandingDesk.tsx
+++ b/apps/nextjs-playground/src/components/r3f/StandingDesk.tsx
@@ -79,7 +79,7 @@ function DeskRig({ heightRef, dirRef, onDisplayUpdate }: DeskRigProps) {
           <iframe
             width="320"
             height="180"
-            src={`https://www.youtube.com/embed/${YOUTUBE_VIDEO_ID}`}
+            src={`https://www.youtube.com/embed/${YOUTUBE_VIDEO_ID}?autoplay=1&mute=1&playsinline=1&loop=1&playlist=${YOUTUBE_VIDEO_ID}`}
             title="YouTube video"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowFullScreen


### PR DESCRIPTION
## Summary
- Append `autoplay=1&mute=1&playsinline=1&loop=1&playlist=$VIDEO_ID` to the embed URL
- Must start muted (browsers block sound autoplay); `loop=1` needs the `playlist` param with the same video id to work
- `playsinline=1` prevents mobile Safari from jumping to the native fullscreen player

https://claude.ai/code/session_01PgzjxBWpdaDx776H7gYJdz