### PR TITLE
docs: drop stale TODO section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,3 @@ monorepo for different playground
 
 - [Next.js playground](https://jyunhanlin.github.io/showroom/nextjs-playground/)
 - [TanStack Start playground (SPA mode)](https://jyunhanlin.github.io/showroom/tanstack-playground/)
-
-TODO
-
-- [ ] build system (Nx, turborepo, ...)


### PR DESCRIPTION
## Summary

- Remove the stale TODO section (build system note) from the root README

## Test plan

- [x] `README.md` renders cleanly with only the playground list

https://claude.ai/code/session_01VPrjTRnoRBMxY1L7wTXwDV