### PR TITLE
docs: rewrite root README with playground index and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,32 @@
-# Showroom (WIP)
+# Showroom
 
-monorepo for different playground
+Monorepo of small JavaScript framework playgrounds, each deployed independently to GitHub Pages.
 
-- [Next.js playground](https://jyunhanlin.github.io/showroom/nextjs-playground/)
-- [TanStack Start playground (SPA mode)](https://jyunhanlin.github.io/showroom/tanstack-playground/)
-- [Astro playground](https://jyunhanlin.github.io/showroom/astro-playground/)
+| Playground                                             | Stack                                                  | Live                                                               |
+| ------------------------------------------------------ | ------------------------------------------------------ | ------------------------------------------------------------------ |
+| [`apps/nextjs-playground`](apps/nextjs-playground)     | Next.js (static export) — R3F / Framer Motion / shadcn | [open](https://jyunhanlin.github.io/showroom/nextjs-playground/)   |
+| [`apps/tanstack-playground`](apps/tanstack-playground) | TanStack Start (SPA mode)                              | [open](https://jyunhanlin.github.io/showroom/tanstack-playground/) |
+| [`apps/astro-playground`](apps/astro-playground)       | Astro (static)                                         | [open](https://jyunhanlin.github.io/showroom/astro-playground/)    |
+
+## Prerequisites
+
+- Node.js 22
+- pnpm (enforced via the root `preinstall` hook)
+
+## Scripts
+
+From the repo root:
+
+| Playground | Dev                 | Build                 | Run                     |
+| ---------- | ------------------- | --------------------- | ----------------------- |
+| Next.js    | `pnpm next:dev`     | `pnpm next:build`     | `pnpm next:start`       |
+| TanStack   | `pnpm tanstack:dev` | `pnpm tanstack:build` | `pnpm tanstack:preview` |
+| Astro      | `pnpm astro:dev`    | `pnpm astro:build`    | `pnpm astro:preview`    |
+
+Repo-wide tooling: `pnpm lint` (oxlint), `pnpm format` (oxfmt).
+
+## Deployment
+
+Each app has its own workflow under `.github/workflows/` that triggers on
+changes to that app's directory, builds with `BASE_PATH=/showroom/<app>/`,
+and publishes to the matching subpath on `jyunhanlin.github.io/showroom/`.


### PR DESCRIPTION
## Summary

- Rewrite the root README to reflect the grown scope: a playground index table (stack + live link), prerequisites, a scripts matrix for all three apps, and a short note on the per-app GH Pages deploy workflows
- Drop the `(WIP)` tag

## Test plan

- [x] Renders cleanly locally (table, links, headers)

https://claude.ai/code/session_01VPrjTRnoRBMxY1L7wTXwDV