### PR TITLE
chore(lint): split oxlint config per app via extends

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["import", "react", "typescript", "unicorn", "jsx-a11y", "nextjs"],
+  "plugins": ["import", "typescript", "unicorn", "jsx-a11y"],
   "categories": {
     "correctness": "error",
     "suspicious": "warn"
@@ -13,19 +13,8 @@
   "rules": {
     "import/no-default-export": "off",
     "import/no-named-as-default": "off",
-    "react/react-in-jsx-scope": "off",
-    "jsx-a11y/alt-text": "warn",
-    "nextjs/no-img-element": "off"
+    "jsx-a11y/alt-text": "warn"
   },
-  "overrides": [
-    {
-      "files": ["apps/tanstack-playground/**"],
-      "rules": {
-        "nextjs/no-head-element": "off",
-        "nextjs/no-html-link-for-pages": "off"
-      }
-    }
-  ],
   "ignorePatterns": [
     "**/node_modules",
     "**/.next",

--- a/apps/astro-playground/.oxlintrc.json
+++ b/apps/astro-playground/.oxlintrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../node_modules/oxlint/configuration_schema.json",
+  "extends": ["../../.oxlintrc.json"]
+}

--- a/apps/nextjs-playground/.oxlintrc.json
+++ b/apps/nextjs-playground/.oxlintrc.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../../node_modules/oxlint/configuration_schema.json",
+  "extends": ["../../.oxlintrc.json"],
+  "plugins": ["react", "nextjs"],
+  "rules": {
+    "react/react-in-jsx-scope": "off",
+    "nextjs/no-img-element": "off"
+  }
+}

--- a/apps/tanstack-playground/.oxlintrc.json
+++ b/apps/tanstack-playground/.oxlintrc.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../../node_modules/oxlint/configuration_schema.json",
+  "extends": ["../../.oxlintrc.json"],
+  "plugins": ["react"],
+  "rules": {
+    "react/react-in-jsx-scope": "off"
+  }
+}


### PR DESCRIPTION
Root config keeps framework-agnostic rules; each app declares its own
plugins (react/nextjs) and extends the root, so framework-specific
concerns live next to the code they affect instead of in a central
overrides block.