### PR TITLE
chore(nextjs): bump tsconfig target from es5 to es2022

### DIFF
--- a/apps/nextjs-playground/tsconfig.json
+++ b/apps/nextjs-playground/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- Bump `apps/nextjs-playground/tsconfig.json` compile target from `es5` to `es2022`.

## Why
TypeScript 6 flags `target: es5` as deprecated (error `TS5107`) and will drop it in TS 7. This change unblocks the dependabot TypeScript 6.0.3 bump (#536). Next 16 + React 19 already target modern runtimes, so `es2022` is appropriate.

## Test plan
- [x] `tsc --noEmit` on `apps/nextjs-playground` passes with TS 5.9.3 (current)
- [x] `tsc --noEmit` on `apps/nextjs-playground` passes with TS 6.0.3 (future, after #536)
- [x] `tsc --noEmit` on `apps/tanstack-playground` passes with TS 6.0.3

https://claude.ai/code/session_01LddeJ2XxwtENKovmXhP85o