### PR TITLE
chore(ci): bump workflow actions to v6

### DIFF
--- a/.github/workflows/astro-playground.yaml
+++ b/.github/workflows/astro-playground.yaml
@@ -14,16 +14,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: latest
           run_install: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/nextjs-playground.yaml
+++ b/.github/workflows/nextjs-playground.yaml
@@ -13,16 +13,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: latest
           run_install: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/tanstack-playground.yaml
+++ b/.github/workflows/tanstack-playground.yaml
@@ -14,16 +14,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: latest
           run_install: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v4 → v6
- Bump `pnpm/action-setup` v4 → v6
- Bump `actions/setup-node` v4 → v6

Applied to all three deploy workflows (astro, nextjs, tanstack playgrounds). Consolidates dependabot #530, #531, #532 into a single PR; those three can be closed once this merges.

## Test plan
- [ ] Verify astro-playground deploy workflow succeeds after merge (push to `apps/astro-playground/**` or workflow file)
- [ ] Verify nextjs-playground deploy workflow succeeds
- [ ] Verify tanstack-playground deploy workflow succeeds

https://claude.ai/code/session_01LddeJ2XxwtENKovmXhP85o