### PR TITLE
chore(dependabot): group weekly bumps by ecosystem and dep type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,24 @@
-# Basic set up for three package managers
+# Grouped weekly updates.
+# Groups bundle non-major bumps into one PR per ecosystem/dependency-type;
+# major bumps still get their own PR so breaking changes can be reviewed in isolation.
 
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      github-actions:
+        patterns:
+          - '*'
 
-  # Maintain dependencies for npm
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      dev-dependencies:
+        dependency-type: 'development'
+      production-dependencies:
+        dependency-type: 'production'


### PR DESCRIPTION
## Summary
Adds grouping to `.github/dependabot.yml`:

- `npm`: one PR/week for **dev-dependencies**, one for **production-dependencies**
- `github-actions`: one PR/week for all action bumps
- Weekly cadence kept as-is

Dependabot's default grouping behaviour keeps **major bumps as separate PRs**, so breaking-change review stays isolated. Non-major (patch/minor) bumps get bundled, which avoids the 8-PRs-sharing-one-lockfile pattern we hit this round.

## Expected effect
Next cycle we should see at most ~3 PRs/week instead of one-per-dep, and merging one won't conflict with the others.

## Test plan
- [ ] Watch next Dependabot run (Mondays ~05:00 UTC) to confirm PRs come in grouped
- [ ] Verify major bumps still arrive as standalone PRs

https://claude.ai/code/session_01LddeJ2XxwtENKovmXhP85o