### PR TITLE
ci: fix pnpm 11 install failures in deploy workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,13 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    # Only propose versions that have aged past pnpm 11's default
+    # minimumReleaseAge (24h supply-chain policy). A few days of margin keeps
+    # the lockfile from ever carrying a too-fresh package that would fail
+    # `pnpm install` in CI; majors soak longer to surface breakage first.
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
     groups:
       dev-dependencies:
         dependency-type: 'development'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,4 @@ packages:
 
 allowBuilds:
   sharp: true
+  esbuild: true


### PR DESCRIPTION
## What broke

All three **Deploy to GitHub Pages** workflows (Astro / Next.js / TanStack) started failing at the `pnpm install` step.

Root cause: `pnpm/action-setup@v6` is pinned to `version: latest`, which now resolves to **pnpm 11** (11.8.0, released 2026-06-18). pnpm 11 ships stricter defaults than the pnpm 10.x we develop against locally, and two of them fail the install:

1. **`ERR_PNPM_IGNORED_BUILDS`** (Astro, TanStack) — pnpm 11 hard-fails when a dependency's build script is not approved. `esbuild@0.27.7` was not in `allowBuilds` (only `sharp` was).
2. **`ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`** (Next.js, TanStack) — pnpm 11 enables `minimumReleaseAge: 1440` (24h) by default. Dependabot's dev-deps bump (#569) pinned `lint-staged@17.0.8` into the lockfile only ~13h after it was published, so the frozen lockfile fails the supply-chain check.

## Fix

- **`pnpm-workspace.yaml`** — approve esbuild's build script (`esbuild: true`).
- **`.github/dependabot.yml`** — add a `cooldown` (3 days default, 7 for majors) so Dependabot only ever proposes versions old enough to satisfy pnpm 11's `minimumReleaseAge`. This keeps the supply-chain protection on while preventing the lockfile from carrying a too-fresh package again.

## Verification

Reproduced and validated locally with `pnpm@11.8.0` in an isolated git worktree (`pnpm install --frozen-lockfile`, `CI=1`):

- Confirmed the exact `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` on `lint-staged@17.0.8`.
- With the time-gate satisfied, the full workspace install completes cleanly — `esbuild` postinstall runs, no `ERR_PNPM_IGNORED_BUILDS`, no other blocked builds.

## Note on the existing lockfile

This PR does **not** rejuvenate the already-committed `lint-staged@17.0.8`; that entry naturally clears pnpm's 24h gate at **2026-06-21 19:36 UTC**. After merging (and past that time), re-run / `workflow_dispatch` the three deploy workflows to confirm green. The esbuild fix is effective immediately and is time-independent.
